### PR TITLE
update js2wasm-cli tsconfig.json

### DIFF
--- a/js2wasm-cli/tsconfig.json
+++ b/js2wasm-cli/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
-    "resolveJsonModule": true,
-    "preserveConstEnums": true,
     "outDir": "./dist/npm",
+    "declaration": true,
+    "declarationMap": true,
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", ""]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
Updated to generate d.ts files.

This fix will enable completion in `import { builder } from 'js2wasm-cli` code on the IDE.

