### PR TITLE
[c2wasm-cli] Fixed a issue where wasm files were not saved properly in the library environment.

### DIFF
--- a/c2wasm-cli/package.json
+++ b/c2wasm-cli/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.6",
   "description": "",
   "main": "dist/npm/index.js",
+  "types": "dist/npm/index.d.ts",
   "files": [
     "dist/**/*"
   ],

--- a/c2wasm-cli/src/build.ts
+++ b/c2wasm-cli/src/build.ts
@@ -165,9 +165,8 @@ export async function buildWasm(fileObject: any, outDir: string) {
       output,
       tasks,
     } as BuildResult;
-    fs.mkdir(outDir, async () => {
-      await saveFileOrError(outDir, filename, result);
-    });
+    fs.mkdirSync(outDir, { recursive: true });
+    await saveFileOrError(outDir, filename, result);
   } catch (error: any) {
     console.log(`Error sending API call: ${error}`);
   }

--- a/c2wasm-cli/tsconfig.json
+++ b/c2wasm-cli/tsconfig.json
@@ -4,6 +4,8 @@
     "resolveJsonModule": true,
     "preserveConstEnums": true,
     "outDir": "./dist/npm",
+    "declaration": true,
+    "declarationMap": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", ""]


### PR DESCRIPTION
- Fixed a issue where built files were not saved when using c2wasm-cli as a library instead of as a CLI.
- Fixed to include type information in npm package